### PR TITLE
Make flashcard breadcrumb visible in dark theme

### DIFF
--- a/mia_base.css
+++ b/mia_base.css
@@ -331,6 +331,13 @@ textarea {
 	--color-level-2: var(--ls-tertiary-background-color);
 }
 
+:is(.dark, .dark-theme) .ls-card {
+	--ls-primary-text-color: #EEEEEE;
+	--ls-title-text-color: #EEEEEE;
+	--color-level-1: var(--ls-secondary-background-color);
+	--color-level-2: var(--ls-tertiary-background-color);
+}
+
 html[data-theme=light] .cp__right-sidebar .block-content {
 	--ls-page-inline-code-bg-color: #E0E0E0;
 	--ls-page-blockquote-bg-color: #E0E0E0;


### PR DESCRIPTION
## Problem

I'm using mia-sans. Screenshots and screen recordings for before/after are included.

### Expected
<img width="600" alt="image" src="https://github.com/playerofgames/logseq-mia-theme/assets/50042066/65813982-6c2f-4f0f-a7ae-0ea04baab9dc">

### Actual
<img width="600" alt="image" src="https://github.com/playerofgames/logseq-mia-theme/assets/50042066/7f5e4eb1-f38b-44de-8ef2-ab318ac35c2f">

## Solution

Looking through the code, it seems that the variable that controls the element color in question is from this snippet:

https://github.com/playerofgames/logseq-mia-theme/blob/4ff045412669f8122ac90e5cd7d4741b594f1027/mia_base.css#L317-L332

Alternative colors for dark theme are set for sidebar, but not for **ls-card**, which is the class used in the flashcards. So I added a similar snippet to L326-L332, using ls-card and adjusting text color to have a hover effect (using #CCCCC will have no hover effect).

```diff
:is(.dark, .dark-theme) .sidebar-item,
:is(.dark, .dark-theme) #main-content-container {
	--ls-primary-text-color: #CCCCCC;
	--ls-title-text-color: #CCCCCC;
	--color-level-1: var(--ls-secondary-background-color);
	--color-level-2: var(--ls-tertiary-background-color);
}

+:is(.dark, .dark-theme) .ls-card {
+	--ls-primary-text-color: #EEEEEE;
+	--ls-title-text-color: #EEEEEE;
+	--color-level-1: var(--ls-secondary-background-color);
+	--color-level-2: var(--ls-tertiary-background-color);
+}
+
```

Choice of #EEEEEE may seem arbitrary but I've seen it used elsewhere so I decided to pick that.


### After this fix

https://github.com/playerofgames/logseq-mia-theme/assets/50042066/f5cd40b0-7dae-4208-9f46-cd8c522cfb25


### Before this fix

https://github.com/playerofgames/logseq-mia-theme/assets/50042066/a11a71c4-3fbc-4149-926d-b41a0675f665